### PR TITLE
Fix token usage and HTML structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ app.post("/submit", async (req, res) => {
     });
     const applicantId = applicant.id;
 
-    const generateSdkToken = await onfido.sdkToken.generate({
+    const sdkTokenResponse = await onfido.sdkToken.generate({
       applicantId: applicantId,
       referrer: "*://*/*",
     });
@@ -41,10 +41,10 @@ app.post("/submit", async (req, res) => {
 
     const workflowRunId = workflowRun.id;
 
-    res.render("index", {
-      sdkToken: generateSdkToken,
-      workflowRunId: workflowRunId,
-    });
+      res.render("index", {
+        sdkToken: sdkTokenResponse.token,
+        workflowRunId: workflowRunId,
+      });
   } catch (error) {
     if (error instanceof OnfidoApiError) {
       console.log(error.message);

--- a/views/form.ejs
+++ b/views/form.ejs
@@ -25,7 +25,6 @@
         width: 240px;
       "
     />
-  <body>
     <div
       class="container h-100 d-flex justify-content-center align-items-center"
     >

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,8 +12,9 @@
       type="text/javascript"
       src="https://assets.onfido.com/web-sdk-releases/12.1.0/onfido.min.js"
     ></script>
-    <body>
-      <img
+  </head>
+  <body>
+    <img
         src="images/onfidoLogo.png"
         alt="Your logo"
         style="
@@ -23,8 +24,6 @@
           width: 240px;
         "
       />
-  </head>
-  <body>
     <div id="onfido-mount"></div>
     <script type="text/javascript">
       //<![CDATA[


### PR DESCRIPTION
## Summary
- correct token extraction from Onfido SDK response
- remove stray `<body>` tags from templates

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683f6310f5d8832d95b5163e3cce9beb